### PR TITLE
Feature/sensitive properties support

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -208,6 +208,7 @@ Attribute Name | Type | Description
 readOnly | boolean |  The field will not be considered when updating the resource
 x-terraform-immutable | boolean |  The field will be used to create a brand new resource; however it can not be updated. Attempts to update this value will result into terraform aborting the update.
 x-terraform-force-new | boolean |  If the value of this property is updated; terraform will delete the previously created resource and create a new one with this value
+x-terraform-sensitive | boolean |  If this meta attribute is present in an object definition property, it will be considered sensitive as far as terraform is concerned, meaning that its value will not be disclosed in the TF state file  
 default | primitive (int, bool, string) | Default value that will be applied to the property if value is not provided by the user (this attribute can not coexist with readOnly)
 ##### <a name="definitionExample">Full Example</a>
 
@@ -254,6 +255,10 @@ definitions:
       force_new_prop:
         type: number
         x-terraform-force-new: true
+
+      sensitive_prop:
+        type: string
+        x-terraform-sensitive: true        
 ```
 
 

--- a/terraform_provider_api/resource_info.go
+++ b/terraform_provider_api/resource_info.go
@@ -10,6 +10,7 @@ import (
 
 const EXT_TF_IMMUTABLE = "x-terraform-immutable"
 const EXT_TF_FORCE_NEW = "x-terraform-force-new"
+const EXT_TF_SENSITIVE = "x-terraform-sensitive"
 
 type CrudResourcesInfo map[string]ResourceInfo
 
@@ -122,6 +123,12 @@ func (r ResourceInfo) createTerraformBasicSchema(propertyName string, property s
 	// it comes back from the api and is stored in the state. This properties are mostly informative.
 	if property.ReadOnly {
 		propertySchema.Computed = true
+	}
+
+	// A sensitive property means that the value will not be disclosed in the state file, preventing secrets from
+	// being leaked
+	if sensitive, ok := property.Extensions.GetBool(EXT_TF_SENSITIVE); ok && sensitive {
+		propertySchema.Sensitive = true
 	}
 
 	if property.Default != nil {


### PR DESCRIPTION
## Proposed changes

Add support for sensitive properties. A new meta attribute has been added, 'x-terraform-sensitive' which allows swagger admins to attach this attribute to object definition properties. When the terraform provider sees this attribute in any of the object properties, it will set up the property schema as sensitive, thus terraform will not disclose the value in the state file.

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [ ] Bugfix (change that fixes current functionality)
- [x] New feature (change that adds new functionality)

Does this Pull Request resolve any open issue? If so, please make sure to link to that issue:

Fixes: #12 

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'Lint' and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)