### PR TITLE
Add support for base path

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -59,9 +59,6 @@ host: "api.server.com"
 - **Description:**  The base path on which the API is served, which is relative to the [`host`](#swaggerHost). 
 If it is not included, the API is served directly under the `host`. The value MUST start with a leading slash (`/`).
 
-*Base path is not supported at the moment. The terraform provider currently relies on the host and the individual API 
-paths to build up the url*
-
 ```yml
 basePath: "/"
 ```

--- a/service_provider_example/resources/swagger.yaml
+++ b/service_provider_example/resources/swagger.yaml
@@ -7,6 +7,7 @@ info:
   contact:
     email: "apiteam@serviceprovider.io"
 host: "localhost:8443"
+basePath: "/"
 tags:
 - name: "cdn"
   description: "Operations about cdns"

--- a/terraform_provider_api/api_spec_analyser.go
+++ b/terraform_provider_api/api_spec_analyser.go
@@ -32,6 +32,7 @@ func (a ApiSpecAnalyser) getCrudResources() CrudResourcesInfo {
 		resourceName := a.getResourceName(pathName)
 		r := ResourceInfo{
 			Name:             resourceName,
+			BasePath:         a.d.BasePath(),
 			Path:             rootPath,
 			Host:             a.d.Spec().Host,
 			HttpSchemes:      a.d.Spec().Schemes,

--- a/terraform_provider_api/resource_info.go
+++ b/terraform_provider_api/resource_info.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-openapi/spec"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
+	"strings"
 )
 
 const EXT_TF_IMMUTABLE = "x-terraform-immutable"
@@ -16,7 +17,8 @@ type CrudResourcesInfo map[string]ResourceInfo
 
 // ResourceInfo serves as translator between swagger definitions and terraform schemas
 type ResourceInfo struct {
-	Name string
+	Name     string
+	BasePath string
 	// Path contains relative path to the resource e,g: /v1/resource
 	Path             string
 	Host             string
@@ -165,6 +167,13 @@ func (r ResourceInfo) getResourceUrl() string {
 	for _, scheme := range r.HttpSchemes {
 		if scheme == "https" {
 			defaultScheme = "https"
+		}
+	}
+	if r.BasePath != "" && r.BasePath != "/" {
+		if strings.Index(r.BasePath, "/") == 0 {
+			return fmt.Sprintf("%s://%s%s%s", defaultScheme, r.Host, r.BasePath, r.Path)
+		} else {
+			return fmt.Sprintf("%s://%s/%s%s", defaultScheme, r.Host, r.BasePath, r.Path)
 		}
 	}
 	return fmt.Sprintf("%s://%s%s", defaultScheme, r.Host, r.Path)


### PR DESCRIPTION
## Proposed changes

Add support for basePath. Swagger files allow users to specify a base path from which all the resources will be under.

For instance, consider the below swagger config:

```
host: "localhost:8443"
basePath: "/api"
```
This should get translated into the following http call to resource - http://host.com/api/resource - if base path is specified. This Pull Request adds support for that.

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [ ] Bugfix (change that fixes current functionality)
- [x] New feature (change that adds new functionality)

Does this Pull Request resolve any open issue? If so, please make sure to link to that issue:

Fixes: #3 

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'Lint' and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)