### PR TITLE
Add support for global security schemes

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -77,6 +77,21 @@ schemes:
     - https
 ```
 
+#### <a name="globalSecuritySchemes">Global Security Schemes</a>
+
+- **Field Name:** schemes
+- **Type:** [string]
+- **Required:** No
+- **Description:** Applies the specified security schemes, corresponding to a security scheme defined in [securityDefinitions](#swaggerSecurityDefinitions)),
+globally to all API operations unless overridden on the operation level.
+
+Global security can be overridden in individual operations to use a different authentication type or no authentication at all:
+
+```yml
+security:
+  - apiKeyAuth: []
+```
+
 #### <a name="swaggerConsumes">Consumes</a>
 
 - **Field Name:** consumes
@@ -275,7 +290,9 @@ definitions:
 - **Field Name:** securityDefinitions
 - **Type:** [Security Definitions](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject)
 - **Required:** This configuration is up to the user
-- **Description:**  Security scheme definitions that can be used across the specification.
+- **Description:**  Security scheme definitions that can be used across the specification. After you have defined the 
+security schemes in securityDefinitions, you can apply them to the whole API or individual operations by adding the 
+security section on the root level (global security schemes) or operation level, respectively.
 
 The API terraform provider supports apiKey type authentication in the header as well as a query parameter.
 

--- a/service_provider_example/resources/swagger.yaml
+++ b/service_provider_example/resources/swagger.yaml
@@ -23,6 +23,9 @@ consumes:
 produces:
 - "application/json"
 
+security:
+  - apikey_auth: []
+
 paths:
   /swagger.json:
     get:
@@ -60,8 +63,8 @@ paths:
           description: "generic error response"
           schema:
             $ref: "#/definitions/error"
-      security:
-        - apikey_auth: []
+      #security: For the sake of the example, this POST operation will use the global security schemes
+      #  - apikey_auth: []
   /v1/cdns/{id}:
     get:
       tags:

--- a/terraform_provider_api/provider_factory.go
+++ b/terraform_provider_api/provider_factory.go
@@ -55,6 +55,7 @@ func (p providerFactory) generateProviderFromAPISpec(apiSpecAnalyser *apiSpecAna
 		r := resourceFactory{
 			http_goclient.HttpClient{HttpClient: &http.Client{}},
 			resourceInfo,
+			newAPIAuthenticator(apiSpecAnalyser.d.Spec().Security),
 		}
 		resource, err := r.createSchemaResource()
 		if err != nil {

--- a/terraform_provider_api/resource_factory.go
+++ b/terraform_provider_api/resource_factory.go
@@ -73,7 +73,7 @@ func (r resourceFactory) readRemote(id string, config providerConfig) (map[strin
 		return nil, err
 	}
 
-	authContext, err := r.apiAuthenticator.prepareAuth(r.resourceInfo.createPathInfo.Get.ID, resourceIDURL, r.resourceInfo.createPathInfo.Get.Security, config)
+	authContext, err := r.apiAuthenticator.prepareAuth(r.resourceInfo.pathInfo.Get.ID, resourceIDURL, r.resourceInfo.pathInfo.Get.Security, config)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (r resourceFactory) update(data *schema.ResourceData, i interface{}) error 
 		return err
 	}
 
-	authContext, err := r.apiAuthenticator.prepareAuth(r.resourceInfo.createPathInfo.Put.ID, resourceIDURL, r.resourceInfo.createPathInfo.Put.Security, i.(providerConfig))
+	authContext, err := r.apiAuthenticator.prepareAuth(r.resourceInfo.pathInfo.Put.ID, resourceIDURL, r.resourceInfo.pathInfo.Put.Security, i.(providerConfig))
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (r resourceFactory) delete(data *schema.ResourceData, i interface{}) error 
 		return err
 	}
 
-	authContext, err := r.apiAuthenticator.prepareAuth(r.resourceInfo.createPathInfo.Delete.ID, resourceIDURL, r.resourceInfo.createPathInfo.Delete.Security, i.(providerConfig))
+	authContext, err := r.apiAuthenticator.prepareAuth(r.resourceInfo.pathInfo.Delete.ID, resourceIDURL, r.resourceInfo.pathInfo.Delete.Security, i.(providerConfig))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

Having the ability to specify a security scheme globally reduces the amount of boiler plate needed in the swagger file. With this improvement, users will be able to specify a global security scheme which will be applicable to all the operations. Operations, on the other hand, should be able to override the global config on the operation level by defining the security policy.

Example of global configuration:

````
security:
  - ApiKeyHeaderAuth: []
  - ApiKeyQueryAuth: []

````

Example of operation level override:

````
 paths:
  /billing_info:
    get:
      summary: Gets the account billing info
      security:
        - ApiKeyQueryAuth: []
````

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [ ] Bugfix (change that fixes current functionality)
- [x] New feature (change that adds new functionality)

Does this Pull Request resolve any open issue? If so, please make sure to link to that issue:

Fixes: #26 

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)